### PR TITLE
fix: clicking org select in audit and switching tabs crashes app

### DIFF
--- a/src/components/form/SelectOrganizations.js
+++ b/src/components/form/SelectOrganizations.js
@@ -306,7 +306,7 @@ const SelectOrganizations = withTheme(
         if (
           menuIsVisible &&
           e.target !== ref.current &&
-          !ref.current.contains(e.target)
+          !ref.current?.contains(e.target)
         ) {
           setMenuIsVisible(false);
           setSelectState(SelectStateEnum.default);


### PR DESCRIPTION
Issue:
Clicking select org then switching causes app to crash
![Screen Shot 2022-04-05 at 3 41 12 PM (2)](https://user-images.githubusercontent.com/14043581/161862928-fb229e2d-775d-41fa-b953-2c71c1155ac8.png)
![Screen Shot 2022-04-05 at 3 41 17 PM (2)](https://user-images.githubusercontent.com/14043581/161862989-d99fd026-cc99-4297-8c31-cd9057f3ae57.png)

Fix:
![Screen Shot 2022-04-05 at 3 41 35 PM (2)](https://user-images.githubusercontent.com/14043581/161863073-9cf9b9bf-76df-404b-8164-17f6db1eb710.png)
![Screen Shot 2022-04-05 at 3 41 38 PM (2)](https://user-images.githubusercontent.com/14043581/161863081-24061792-b387-495b-9f09-8eead2f9f67b.png)

