### PR TITLE
feat: enable audit sort order at api level

### DIFF
--- a/src/pages/Audit/index.js
+++ b/src/pages/Audit/index.js
@@ -95,11 +95,22 @@ const Audit = withRouter(() => {
   const { audit, organizations } = useSelector(store => store.climateWarehouse);
   const [selectedOrgUid, setSelectedOrgUid] = useState(null);
   const [selectedAuditItem, setSelectedAuditItem] = useState(null);
-  const [isAscendingSorted, setIsAscendingSorted] = useState(false);
+  const [auditSortOrder, setAuditSortOrder] = useState('DESC');
 
   useEffect(() => {
     dispatch(getOrganizationData());
+    const storageAuditSortOrder = localStorage.getItem('auditSortOrder');
+    console.log('storageAuditSortOrder', storageAuditSortOrder);
+    if (storageAuditSortOrder) {
+      setAuditSortOrder(storageAuditSortOrder);
+    }
   }, []);
+
+  const changeSortOrder = () => {
+    const newSortOrder = auditSortOrder === 'DESC' ? 'ASC' : 'DESC';
+    localStorage.setItem('auditSortOrder', newSortOrder);
+    setAuditSortOrder(newSortOrder);
+  };
 
   const onOrganizationSelect = selectedOption => {
     const orgUid = selectedOption[0].orgUid;
@@ -110,7 +121,7 @@ const Audit = withRouter(() => {
         page: 1,
         limit: constants.MAX_AUDIT_TABLE_SIZE,
         useMockedResponse: true,
-        order: isAscendingSorted ? 'ASC' : 'DESC',
+        order: auditSortOrder,
       }),
     );
   };
@@ -129,10 +140,8 @@ const Audit = withRouter(() => {
           width="200px"
           onChange={onOrganizationSelect}
         />
-        <StyledSortButtonContainer
-          onClick={() => setIsAscendingSorted(!isAscendingSorted)}
-        >
-          {isAscendingSorted ? (
+        <StyledSortButtonContainer onClick={changeSortOrder}>
+          {auditSortOrder === 'ASC' ? (
             <>
               <Body>
                 <FormattedMessage id="sort-descending" />
@@ -163,7 +172,7 @@ const Audit = withRouter(() => {
                   page: val + 1,
                   limit: constants.MAX_AUDIT_TABLE_SIZE,
                   useMockedResponse: true,
-                  order: isAscendingSorted ? 'ASC' : 'DESC',
+                  order: auditSortOrder,
                 }),
               )
             }

--- a/src/pages/Audit/index.js
+++ b/src/pages/Audit/index.js
@@ -120,7 +120,7 @@ const Audit = withRouter(() => {
         orgUid,
         page: 1,
         limit: constants.MAX_AUDIT_TABLE_SIZE,
-        useMockedResponse: true,
+        useMockedResponse: false,
         order: auditSortOrder,
       }),
     );
@@ -171,7 +171,7 @@ const Audit = withRouter(() => {
                   orgUid: selectedOrgUid,
                   page: val + 1,
                   limit: constants.MAX_AUDIT_TABLE_SIZE,
-                  useMockedResponse: true,
+                  useMockedResponse: false,
                   order: auditSortOrder,
                 }),
               )

--- a/src/pages/Audit/index.js
+++ b/src/pages/Audit/index.js
@@ -71,14 +71,21 @@ const StyledTr = styled('tr')`
   }
 `;
 
-const StyledIconContainer = styled('div')`
+const StyledSortButtonContainer = styled.div`
+  margin-left: 10px;
+  border: 0.0625rem solid #d9d9d9;
+  height: 2.5rem;
+  padding: 0.5rem 0.75rem 0.5rem 0.75rem;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: row;
+  white-space: nowrap;
+  min-width: 200px;
   cursor: pointer;
 `;
 
-const StyledSortContainer = styled('div')`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+const StyledIconContainer = styled('div')`
+  color: #3b8ee0;
 `;
 
 const Audit = withRouter(() => {
@@ -88,7 +95,7 @@ const Audit = withRouter(() => {
   const { audit, organizations } = useSelector(store => store.climateWarehouse);
   const [selectedOrgUid, setSelectedOrgUid] = useState(null);
   const [selectedAuditItem, setSelectedAuditItem] = useState(null);
-  const [isChronologicallySorted, setIsChronologicallySorted] = useState(false);
+  const [isAscendingSorted, setIsAscendingSorted] = useState(false);
 
   useEffect(() => {
     dispatch(getOrganizationData());
@@ -102,24 +109,14 @@ const Audit = withRouter(() => {
         orgUid,
         page: 1,
         limit: constants.MAX_AUDIT_TABLE_SIZE,
-        useMockedResponse: false,
+        useMockedResponse: true,
+        order: isAscendingSorted ? 'ASC' : 'DESC',
       }),
     );
   };
 
   if (!organizations) {
     return null;
-  }
-
-  let sortedAuditArray = audit?.data ? [...audit?.data] : null;
-  if (sortedAuditArray) {
-    let sortSign = isChronologicallySorted ? -1 : 1;
-    sortedAuditArray.sort(
-      (a, b) =>
-        sortSign *
-        (new Date(parseInt(b.onchainConfirmationTimeStamp) * 1000).getTime() -
-          new Date(parseInt(a.onchainConfirmationTimeStamp) * 1000).getTime()),
-    );
   }
 
   return (
@@ -132,6 +129,29 @@ const Audit = withRouter(() => {
           width="200px"
           onChange={onOrganizationSelect}
         />
+        <StyledSortButtonContainer
+          onClick={() => setIsAscendingSorted(!isAscendingSorted)}
+        >
+          {isAscendingSorted ? (
+            <>
+              <Body>
+                <FormattedMessage id="sort-descending" />
+              </Body>
+              <StyledIconContainer>
+                <AscendingClockIcon width={'1.5em'} height={'1.5em'} />
+              </StyledIconContainer>
+            </>
+          ) : (
+            <>
+              <Body>
+                <FormattedMessage id="sort-ascending" />
+              </Body>
+              <StyledIconContainer>
+                <DescendingClockIcon width={'1.5em'} height={'1.5em'} />
+              </StyledIconContainer>
+            </>
+          )}
+        </StyledSortButtonContainer>
         {selectedOrgUid && audit?.page && audit?.pageCount && (
           <Pagination
             current={audit.page - 1}
@@ -142,7 +162,8 @@ const Audit = withRouter(() => {
                   orgUid: selectedOrgUid,
                   page: val + 1,
                   limit: constants.MAX_AUDIT_TABLE_SIZE,
-                  useMockedResponse: false,
+                  useMockedResponse: true,
+                  order: isAscendingSorted ? 'ASC' : 'DESC',
                 }),
               )
             }
@@ -157,14 +178,14 @@ const Audit = withRouter(() => {
           </div>
         )}
       </StyledHeaderContainer>
-      {!sortedAuditArray && (
+      {!audit?.data && (
         <StyledBodyNoDataFound>
           <H3>
             <FormattedMessage id="no-audit-data" />
           </H3>
         </StyledBodyNoDataFound>
       )}
-      {selectedOrgUid && sortedAuditArray?.length > 0 && (
+      {selectedOrgUid && audit?.data?.length > 0 && (
         <StyledBodyContainer>
           <StyledTable>
             <thead>
@@ -176,26 +197,9 @@ const Audit = withRouter(() => {
                   </Body>
                 </StyledTh>
                 <StyledTh>
-                  <StyledSortContainer>
-                    <Body size="Bold">
-                      <FormattedMessage id="timestamp" />
-                    </Body>
-                    <StyledIconContainer>
-                      {isChronologicallySorted ? (
-                        <DescendingClockIcon
-                          width={'1.5em'}
-                          height={'1.5em'}
-                          onClick={() => setIsChronologicallySorted(false)}
-                        />
-                      ) : (
-                        <AscendingClockIcon
-                          width={'1.5em'}
-                          height={'1.5em'}
-                          onClick={() => setIsChronologicallySorted(true)}
-                        />
-                      )}
-                    </StyledIconContainer>
-                  </StyledSortContainer>
+                  <Body size="Bold">
+                    <FormattedMessage id="timestamp" />
+                  </Body>
                 </StyledTh>
                 <StyledTh>
                   <Body size="Bold">
@@ -210,8 +214,8 @@ const Audit = withRouter(() => {
               </StyledTr>
             </thead>
             <tbody>
-              {sortedAuditArray?.length &&
-                sortedAuditArray.map(auditItem => (
+              {audit?.data?.length &&
+                audit?.data.map(auditItem => (
                   <StyledTr key={auditItem.id}>
                     <StyledTd>
                       {auditItem.change && (

--- a/src/store/actions/climateWarehouseActions.js
+++ b/src/store/actions/climateWarehouseActions.js
@@ -1083,7 +1083,7 @@ export const getAudit = options => {
     if (options?.orgUid && options?.limit && options?.page) {
       dispatch(
         getClimateWarehouseTable(
-          `${constants.API_HOST}/audit?orgUid=${options.orgUid}&limit=${options.limit}&page=${options.page}`,
+          `${constants.API_HOST}/audit?orgUid=${options.orgUid}&limit=${options.limit}&page=${options.page}&order=${options.order}`,
           actions.GET_AUDIT,
           mockedAuditResponse({
             orgUid: options.orgUid,

--- a/src/translations/tokens/en-US.json
+++ b/src/translations/tokens/en-US.json
@@ -357,5 +357,4 @@
   "invalid-uid": "Enter valid UID",
   "sort-ascending": "Sort ascending",
   "sort-descending": "Sort descending"
-  "invalid-uid": "Enter valid UID"
 }

--- a/src/translations/tokens/en-US.json
+++ b/src/translations/tokens/en-US.json
@@ -347,5 +347,12 @@
   "add-new-label": "Add new label",
   "select-from-all-labels": "Select from all existing labels",
   "select-label-by-project": "Select label by project",
-  "way-to-add-label": "Select a way to add a label"
+  "way-to-add-label": "Select a way to add a label",
+  "port": "Port",
+  "ip": "Ip",
+  "invalid-ip": "Enter valid Ip",
+  "invalid-port": "Enter valid port number",
+  "invalid-uid": "Enter valid UID",
+  "sort-ascending": "Sort ascending",
+  "sort-descending": "Sort descending"
 }

--- a/src/translations/tokens/es.json
+++ b/src/translations/tokens/es.json
@@ -329,5 +329,12 @@
   "add-new-label": "Agregar nueva etiqueta",
   "select-from-all-labels": "Seleccionar de todas las etiquetas existentes",
   "select-label-by-project": "Seleccionar etiqueta por proyecto",
-  "way-to-add-label": "Seleccione una forma de agregar una etiqueta"
+  "way-to-add-label": "Seleccione una forma de agregar una etiqueta",
+  "port": "Puerto",
+  "ip": "Ip",
+  "invalid-ip": "Ingrese IP valida",
+  "invalid-port": "Introduzca un número de puerto válido",
+  "invalid-uid": "Ingrese UID válido",
+  "sort-ascending": "Orden ascendente",
+  "sort-descending": "Orden descendiente"
 }

--- a/src/translations/tokens/es.json
+++ b/src/translations/tokens/es.json
@@ -339,5 +339,4 @@
   "invalid-uid": "Ingrese UID válido",
   "sort-ascending": "Orden ascendente",
   "sort-descending": "Orden descendiente"
-  "invalid-uid": "Ingrese UID válido"
 }

--- a/src/translations/tokens/ja.json
+++ b/src/translations/tokens/ja.json
@@ -339,5 +339,4 @@
   "invalid-uid": "有効なUIDを入力してください",
   "sort-ascending": "ソート昇順",
   "sort-descending": "降順で並べ替える"
-  "invalid-uid": "有効なUIDを入力してください"
 }

--- a/src/translations/tokens/ja.json
+++ b/src/translations/tokens/ja.json
@@ -329,5 +329,12 @@
   "add-new-label": "新しいラベルを追加",
   "select-from-all-labels": "既存のすべてのラベルから選択",
   "select-label-by-project": "プロジェクトごとにラベルを選択",
-  "way-to-add-label": "ラベルを追加する方法を選択してください"
+  "way-to-add-label": "ラベルを追加する方法を選択してください",
+  "port": "ポート",
+  "ip": "Ip",
+  "invalid-ip": "有効なIPを入力してください",
+  "invalid-port": "有効なポート番号を入力してください",
+  "invalid-uid": "有効なUIDを入力してください",
+  "sort-ascending": "ソート昇順",
+  "sort-descending": "降順で並べ替える"
 }


### PR DESCRIPTION
- [x] store sort order, for later usage of the user
- [x] move icon from table header to header of main content next to organizations select
- [x] DESC is default sorting order &order = 'DESC'|'ASC'

![image](https://user-images.githubusercontent.com/82083960/162260615-71e111c7-c34f-4e58-928f-f6c32bbeba87.png)
