### PR TITLE
feat: added manual input for date

### DIFF
--- a/src/components/blocks/DateSelect.js
+++ b/src/components/blocks/DateSelect.js
@@ -120,7 +120,7 @@ const DateSelect = ({
               <Input
                 ref={inputRef}
                 {...inputProps}
-                placeholder="Select Date"
+                placeholder="YYYY-MM-DD"
                 disabled={disabled}
               />
               {InputProps?.endAdornment}


### PR DESCRIPTION
Date field already has manual input feature. So I just added a placeholder with the format
<img width="191" alt="Screen Shot 2022-06-14 at 5 36 00 PM" src="https://user-images.githubusercontent.com/14043581/173713143-4b1e11c1-9683-46d6-9f6a-888345978e3e.png">
