### PR TITLE
Deploy to s3 automation

### DIFF
--- a/.github/workflows/deploy-s3.yml
+++ b/.github/workflows/deploy-s3.yml
@@ -15,6 +15,8 @@ jobs:
       - name: Install AWS CLI
         run: |
             apt-get update
+            export DEBIAN_FRONTEND=noninteractive
+            export TZ=Etc/UTC
             apt-get install -y awscli
 
       - name: Checkout Code

--- a/.github/workflows/deploy-s3.yml
+++ b/.github/workflows/deploy-s3.yml
@@ -49,4 +49,4 @@ jobs:
 
       - name: Upload build folder to S3
         run: |
-          aws s3 sync --dryrun --delete --no-progress ./build/* s3://climatewarehouse/
+          aws s3 sync --dryrun --delete --no-progress ./build/ s3://climatewarehouse/

--- a/.github/workflows/deploy-s3.yml
+++ b/.github/workflows/deploy-s3.yml
@@ -3,7 +3,7 @@ name: Deploy to S3
 on:
   push:
     branches:
-      - deploy-to-s3-automation
+      - main
 
 permissions:
   id-token: write

--- a/.github/workflows/deploy-s3.yml
+++ b/.github/workflows/deploy-s3.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Install AWS CLI
         run: |
-            sudo apt-get install -y awscli
+            apt-get install -y awscli
 
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/.github/workflows/deploy-s3.yml
+++ b/.github/workflows/deploy-s3.yml
@@ -8,7 +8,9 @@ on:
 jobs:
   build-and-deploy:
     name: Build Climate Warehouse App and Upload to S3
-    runs-on: ubuntu-latest
+    runs-on: [k8s-public]
+    container:
+      image: ubuntu:latest
     steps:
       - name: Install AWS CLI
         run: |

--- a/.github/workflows/deploy-s3.yml
+++ b/.github/workflows/deploy-s3.yml
@@ -1,0 +1,60 @@
+name: Deploy to S3
+
+on:
+  push:
+    branches:
+      - deploy-to-s3-automation
+
+jobs:
+  build-and-deploy:
+    name: Build Linux Installer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Setup Node 16.x
+        uses: actions/setup-node@v2.4.1
+        with:
+          node-version: '16.x'
+
+      - name: npm install
+        run: |
+          node --version
+          npm install
+
+      - name: Vault Login
+        uses: Chia-Network/actions/vault/login@main
+        with:
+          vault_url: ${{ secrets.VAULT_URL }}
+          role_name: github
+
+      - name: Get ephemeral aws credentials
+        uses: Chia-Network/actions/vault/aws-sts@main
+        with:
+          vault_url: ${{ secrets.VAULT_URL }}
+          vault_token: ${{ env.VAULT_TOKEN }}
+          backend_name: aws-carbon
+          role_name: terraform
+
+  deploy:
+    name: Deploy to S3
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Vault Login
+        uses: Chia-Network/actions/vault/login@main
+        with:
+          vault_url: ${{ secrets.VAULT_URL }}
+          role_name: github
+
+      - name: Get ephemeral aws credentials
+        uses: Chia-Network/actions/vault/aws-sts@main
+        with:
+          vault_url: ${{ secrets.VAULT_URL }}
+          vault_token: ${{ env.VAULT_TOKEN }}
+          backend_name: aws-carbon
+          role_name: cw-s3
+
+

--- a/.github/workflows/deploy-s3.yml
+++ b/.github/workflows/deploy-s3.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - deploy-to-s3-automation
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build-and-deploy:
     name: Build Climate Warehouse App and Upload to S3

--- a/.github/workflows/deploy-s3.yml
+++ b/.github/workflows/deploy-s3.yml
@@ -7,9 +7,13 @@ on:
 
 jobs:
   build-and-deploy:
-    name: Build Linux Installer
+    name: Build Climate Warehouse App and Upload to S3
     runs-on: ubuntu-latest
     steps:
+      - name: Install AWS CLI
+        run: |
+            sudo apt-get install -y awscli
+
       - name: Checkout Code
         uses: actions/checkout@v2
 
@@ -18,10 +22,11 @@ jobs:
         with:
           node-version: '16.x'
 
-      - name: npm install
+      - name: npm install and build
         run: |
           node --version
           npm install
+          npm run build
 
       - name: Vault Login
         uses: Chia-Network/actions/vault/login@main
@@ -35,26 +40,8 @@ jobs:
           vault_url: ${{ secrets.VAULT_URL }}
           vault_token: ${{ env.VAULT_TOKEN }}
           backend_name: aws-carbon
-          role_name: terraform
+          role_name: cw-s3-deploy
 
-  deploy:
-    name: Deploy to S3
-    runs-on: ubuntu-latest
-    needs:
-      - build
-    steps:
-      - name: Vault Login
-        uses: Chia-Network/actions/vault/login@main
-        with:
-          vault_url: ${{ secrets.VAULT_URL }}
-          role_name: github
-
-      - name: Get ephemeral aws credentials
-        uses: Chia-Network/actions/vault/aws-sts@main
-        with:
-          vault_url: ${{ secrets.VAULT_URL }}
-          vault_token: ${{ env.VAULT_TOKEN }}
-          backend_name: aws-carbon
-          role_name: cw-s3
-
-
+      - name: Upload build folder to S3
+        run: |
+          aws s3 sync --dryrun --delete --no-progress ./build/* s3://climatewarehouse/

--- a/.github/workflows/deploy-s3.yml
+++ b/.github/workflows/deploy-s3.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - name: Install AWS CLI
         run: |
+            apt-get update
             apt-get install -y awscli
 
       - name: Checkout Code

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "climate-warehouse",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": true,
   "author": "Chia Network Inc. <hello@chia.net>",
   "homepage": "./",


### PR DESCRIPTION
Create deployment to S3 for Climate Warehouse UI.  This was previously in a separate repo, but makes the most sense to have here.  Straight-forward build and deploy of the code.  This has a `dryrun` flag which will simulate the deploy for review.  If it all looks good, a subsequent pull request will remove that flag and do the real deployment.  