### PR TITLE
Configurable API / APP URLs, and updated default value

### DIFF
--- a/.github/workflows/deploy-s3.yml
+++ b/.github/workflows/deploy-s3.yml
@@ -37,6 +37,9 @@ jobs:
           node-version: '16.x'
 
       - name: npm install and build
+        env:
+          REACT_APP_API_HOST: "https://api-green.climatewarehouse.chia.net/v1"
+          REACT_APP_APP_URL: "http://green-cw-ui.s3-website-us-west-2.amazonaws.com/"
         run: |
           node --version
           npm install

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,13 +1,14 @@
 import _ from 'lodash';
 
 const hostName = String(_.get(window, 'location.hostname', ''));
+const protocol = String(_.get(window, 'location.protocol', 'http'));
 
 export default {
   // if running locally use localhost api, otherwise use observer node api
   API_HOST:
     _.isEmpty(hostName) || hostName.includes('localhost')
       ? 'http://localhost:31310/v1'
-      : 'https://api-green.climatewarehouse.chia.net/v1',
+      : `${protocol}//${hostName}/api/v1`,
   APP_URL: 'https://app.climatewarehouse.chia.net/',
   MAX_TABLE_SIZE: 7,
   MAX_AUDIT_TABLE_SIZE: 20,

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -9,7 +9,9 @@ export default {
     _.isEmpty(hostName) || hostName.includes('localhost')
       ? 'http://localhost:31310/v1'
       : `${protocol}//${hostName}/api/v1`,
-  APP_URL: 'https://app.climatewarehouse.chia.net/',
+  APP_URL: _.isEmpty(hostName) || hostName.includes('localhost')
+      ? 'https://app.climatewarehouse.chia.net/'
+      : `${protocol}//${hostName}/`,
   MAX_TABLE_SIZE: 7,
   MAX_AUDIT_TABLE_SIZE: 20,
   HEADER_HEIGHT: 64, // Needed to be used to calculate max height for body components

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,17 +1,32 @@
 import _ from 'lodash';
 
+const buildAPIHost = process.env.REACT_APP_API_HOST;
+const buildAPPURL = process.env.REACT_APP_APP_URL;
 const hostName = String(_.get(window, 'location.hostname', ''));
 const protocol = String(_.get(window, 'location.protocol', 'http'));
 
+let apiHost, appUrl;
+
+if (!_.isEmpty(buildAPIHost)) {
+  apiHost = buildAPIHost;
+} else {
+  apiHost = _.isEmpty(hostName) || hostName.includes('localhost')
+      ? 'http://localhost:31310/v1'
+      : `${protocol}//${hostName}/api/v1`;
+}
+
+if (!_.isEmpty(buildAPPURL)) {
+  appUrl = buildAPPURL;
+} else {
+  appUrl = _.isEmpty(hostName) || hostName.includes('localhost')
+      ? 'https://app.climatewarehouse.chia.net/'
+      : `${protocol}//${hostName}/`;
+}
+
 export default {
   // if running locally use localhost api, otherwise use observer node api
-  API_HOST:
-    _.isEmpty(hostName) || hostName.includes('localhost')
-      ? 'http://localhost:31310/v1'
-      : `${protocol}//${hostName}/api/v1`,
-  APP_URL: _.isEmpty(hostName) || hostName.includes('localhost')
-      ? 'https://app.climatewarehouse.chia.net/'
-      : `${protocol}//${hostName}/`,
+  API_HOST: apiHost,
+  APP_URL: appUrl,
   MAX_TABLE_SIZE: 7,
   MAX_AUDIT_TABLE_SIZE: 20,
   HEADER_HEIGHT: 64, // Needed to be used to calculate max height for body components


### PR DESCRIPTION
Allow setting API host and APP URL at build time. If set, those always take precedence. Otherwise, fallback to either the localhost setting or else the `<window.location>/api` path for a more flexible/broadly applicable api url by default.