### PR TITLE
fix server URLs that end with '/'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [1.0.20](https://github.com/Chia-Network/climate-warehouse-ui/compare/1.0.18...1.0.20) (2023-04-03)
+## [1.0.19](https://github.com/Chia-Network/climate-warehouse-ui/compare/1.0.18...1.0.19) (2023-04-03)
 
 
 ### Features

--- a/src/store/actions/climateWarehouseActions.js
+++ b/src/store/actions/climateWarehouseActions.js
@@ -2558,30 +2558,38 @@ export const getVintages = options => {
 const fetchWrapper = async (url, payload) => {
   const apiKey = localStorage.getItem('apiKey');
   const serverAddress = localStorage.getItem('serverAddress');
-  const doesSignInDataExist = apiKey != null && serverAddress != null;
 
-  if (doesSignInDataExist) {
-    const payloadWithApiKey = { ...payload };
-    if (payloadWithApiKey?.headers) {
-      payloadWithApiKey.headers = {
-        ...payloadWithApiKey.headers,
-        'x-api-key': apiKey,
-      };
-    } else {
-      payloadWithApiKey.headers = { 'x-api-key': apiKey };
+  // Check if serverAddress is set and is a string; this results in changing the URL to the stored server address
+  // and adds the API key header (if applicable).
+  if (serverAddress && serverAddress.endsWith) {
+    const newPayload = { ...payload };
+
+    // If API key was set, add the header
+    if (apiKey) {
+      if (newPayload.headers) {
+        // Add to existing headers
+        newPayload.headers = {
+          ...newPayload.headers,
+          'x-api-key': apiKey,
+        };
+      } else {
+        // Create headers object if it doesn't exist
+        newPayload.headers = { 'x-api-key': apiKey };
+      }
     }
 
-    const serverAddressUrl =
-      serverAddress[serverAddress.length - 1] !== '/'
-        ? `${serverAddress}/`
-        : serverAddressUrl;
+    //Ensure server address ends in a forward slash
+    const addressWithSlash = serverAddress.endsWith('/')
+      ? serverAddress
+      : serverAddress + '/';
 
+    // Replace original URL with stored server URL (with slash)
     const newUrl = url.replace(
       /(https:|http:|)(^|\/\/)(.*?\/)/g,
-      serverAddressUrl,
+      addressWithSlash,
     );
 
-    return fetch(newUrl, payloadWithApiKey);
+    return fetch(newUrl, newPayload);
   }
 
   return fetch(url, payload);


### PR DESCRIPTION
Fixed a bug that caused all requests to fail if you specified a server address that ends in a forward slash. I also changed the function to work if the API key was not specified, related to this issue https://github.com/Chia-Network/climate-warehouse-ui/issues/1046

I also cleaned up the function a bit and added comments for clarity.